### PR TITLE
Handle exceptions in the main thread

### DIFF
--- a/src/streamexecutors/stream.py
+++ b/src/streamexecutors/stream.py
@@ -1,5 +1,5 @@
 import time
-from queue import Queue
+from queue import Queue, Full, Empty
 from concurrent.futures import Executor, ThreadPoolExecutor, ProcessPoolExecutor
 from concurrent.futures.process import _get_chunks, _process_chunk
 from functools import partial
@@ -8,31 +8,8 @@ import contextlib
 import threading
 import itertools
 
-class CancelledError(Exception):
-    pass
-
-
-# http://stackoverflow.com/a/40257140/336527
-@contextlib.contextmanager
-def _non_blocking_lock(lock):
-    locked = lock.acquire(False)
-    try:
-        yield locked
-    finally:
-        if locked:
-            lock.release()
-
 
 class StreamExecutor(Executor):
-    _cleanup_callbacks = []
-
-    @classmethod
-    def cleanup_thread(cls):
-        threading.main_thread().join()
-        for fn in cls._cleanup_callbacks:
-            fn()
-        time.sleep(10)
-
     def map(self, fn, *iterables, timeout=None, chunksize=1, buffer_size=10000):
         """Returns an iterator equivalent to map(fn, iter).
 
@@ -71,12 +48,9 @@ class StreamExecutor(Executor):
         elif buffer_size <= 0:
             raise ValueError('buffer_size must be a positive number')
 
-        iterators = [iter(iterable) for iterable in iterables]
+        current_thread = threading.current_thread()
 
-        # Set to True to gracefully terminate all producers.
-        cancel = False
-        # Must acquire this lock before assigning to cancel.
-        cancel_lock = threading.Lock()
+        iterators = [iter(iterable) for iterable in iterables]
 
         # Deadlocks on the two queues are avoided using the following rule.
         # The writer guarantees to place a sentinel value into the buffer
@@ -85,13 +59,13 @@ class StreamExecutor(Executor):
         # and to stop reading after that. Any value of type BaseException is
         # treated as a sentinel.
         future_buffer = Queue(maxsize=buffer_size)
+        cancel = False
 
         # This function will run in a separate thread.
         def consume_inputs():
-            while True:
-                if cancel:
-                    future_buffer.put(CancelledError())
-                    return
+            nonlocal cancel
+            while not cancel:
+                future = None
                 try:
                     args = [next(iterator) for iterator in iterators]
                 except BaseException as e:
@@ -99,47 +73,40 @@ class StreamExecutor(Executor):
                     # exception is due to an error in the input generator. We
                     # forward the exception downstream so it can be raised
                     # when client iterates through the result of map.
-                    future_buffer.put(e)
-                    return
-                try:
-                    future = self.submit(fn, *args)
-                except BaseException as e:
-                    # E.g., RuntimeError from shut down executor.
-                    # Forward the new exception downstream.
-                    future_buffer.put(e)
-                    return
-                future_buffer.put(future)
-
-        # This function will run in the main thread.
-        def produce_results():
-            # This function may run in the main thread or in a cleanup thread.
-            # We must keep it thread-safe and idempotent.
-            def cleanup():
-                nonlocal cancel
-                nonlocal last_exception
-                # We only need to run cleanup once, so if we can't acquire lock, do nothing.
-                with _non_blocking_lock(cancel_lock) as locked:
-                    if locked and not cancel:
-                        cancel = True
-                        while True:
-                            future = future_buffer.get()
-                            if isinstance(future, BaseException):
-                                break
-                            else:
-                                future.cancel()
-                        if last_exception:
-                            # We are in the main thread, and this was a result of an exception.
-                            raise last_exception
-            self._cleanup_callbacks.append(cleanup)
-
-            # Ensure cleanup happens even if client never starts this generator.
-            last_exception = None
-            try:
-                yield None
-            except GeneratorExit as exc:
-                last_exception = exc
-                cleanup()
+                    future = e
+                if not future:
+                    try:
+                        future = self.submit(fn, *args)
+                    except BaseException as e:
+                        # E.g., RuntimeError from shut down executor.
+                        # Forward the new exception downstream.
+                        future = e
+                while True:
+                    try:
+                        future_buffer.put(future, timeout=1)
+                    except Full:
+                        if cancel or not current_thread.is_alive():
+                            cancel = True
+                            break
+                        else:
+                            continue
+                    if isinstance(future, BaseException):
+                        return
+                    else:
+                        break
             while True:
+                try:
+                    future = future_buffer.get(block=False)
+                except Empty:
+                    return
+                if isinstance(future, BaseException):
+                    return
+                future.cancel()
+
+        # Instances of this class will be created and their methods executed in the main thread.
+        class Producer:
+            def __next__(self):
+                nonlocal cancel
                 future = future_buffer.get()
                 if isinstance(future, BaseException):
                     # Reraise upstream exceptions at the map call site.
@@ -148,20 +115,25 @@ class StreamExecutor(Executor):
                     remaining_timeout = None
                 else:
                     remaining_timeout = end_time - time.time()
-                # Reraise new exceptions (errors in the callable fn, TimeOut,
-                # GeneratorExit) at map call site, but also cancel upstream.
+                # Any exceptions (errors in the callable fn, TimeOut,
+                # GeneratorExit) will be raised at map call site.
                 try:
-                    yield future.result(remaining_timeout)
-                except BaseException as exc:
-                    last_exception = exc
-                    cleanup()
+                    return future.result(remaining_timeout)
+                except BaseException:
+                    cancel = True
+                    raise
+
+            def __iter__(self):
+                return self
+
+            def __del__(self):
+                nonlocal cancel
+                cancel = True
 
         thread = threading.Thread(target=consume_inputs)
         thread.start()
-        result = produce_results()
-        # Consume the dummy `None` result
-        next(result)
-        return result
+        return Producer()
+
 
 class StreamThreadPoolExecutor(StreamExecutor, ThreadPoolExecutor): ...
 
@@ -175,5 +147,3 @@ class StreamProcessPoolExecutor(StreamExecutor, ProcessPoolExecutor):
                               _get_chunks(*iterables, chunksize=chunksize),
                               timeout=timeout, buffer_size=buffer_size)
         return itertools.chain.from_iterable(results)
-
-threading.Thread(target=StreamExecutor.cleanup_thread).start()

--- a/test/test_stream.py
+++ b/test/test_stream.py
@@ -114,3 +114,10 @@ def test_timing_10_workers(test_class):
         for x in it:
             pass
         assert t.elapsed() == approx(3)
+
+@pytest.mark.xfail
+@pytest.mark.parametrize("test_class", test_classes_timing)
+def test_abnormal_termination(test_class):
+    executor = test_class(max_workers=2)
+    m = executor.map(process, count())
+    raise RuntimeError()

--- a/test/test_stream.py
+++ b/test/test_stream.py
@@ -115,8 +115,9 @@ def test_timing_10_workers(test_class):
             pass
         assert t.elapsed() == approx(3)
 
+# Imitate abnormal main thread exit
 @pytest.mark.xfail
-@pytest.mark.parametrize("test_class", test_classes_timing)
+@pytest.mark.parametrize("test_class", test_classes)
 def test_abnormal_termination(test_class):
     executor = test_class(max_workers=2)
     m = executor.map(process, count())


### PR DESCRIPTION
Attempt to fix #1 .

For some reason, the entire process does not exit at the end, even though it seems all the threads complete successfully.

Perhaps this has something to do with the daemonic status of the worker threads started in the executor. Perhaps, this is just the interpreter itself getting confused when the main thread is gone but other threads are running. I really can't tell.